### PR TITLE
Use Rails autoloader if possible

### DIFF
--- a/lib/aasm-statecharts/aasm_state_charts.rb
+++ b/lib/aasm-statecharts/aasm_state_charts.rb
@@ -63,7 +63,7 @@ module AASM_StateChart
 
       load_rails unless @options[:no_rails]
 
-      @models = get_models options[:all], options[:models]
+      @models = get_models options
 
       @show_transition_table = options[:transition_table]
 
@@ -178,9 +178,16 @@ module AASM_StateChart
     end
 
 
-    def get_models(all_option, models)
+    def get_models(options)
 
+      all_option, models = options[:all], options[:models]
       model_classes = []
+
+      unless options[:no_rails]
+        # use Rails autoloader for passed-in classes
+        puts "Using Rails Class loader!"
+        return model_classes + models
+      end
 
       if all_option
         puts "\n\nTBD: all_option\n\n"

--- a/lib/aasm-statecharts/chart_renderer.rb
+++ b/lib/aasm-statecharts/chart_renderer.rb
@@ -112,6 +112,7 @@ module AASM_StateChart
     def save(filename, format: 'png', graph_options: (@default_config[:graph_style]))
       opts = {}
       opts.merge!(graph_options).merge({ format => filename }) # FIXME why can't I merge in graph_options? can't seem to use opts
+      FileUtils.mkdir_p  File.dirname(filename)
       @graph.output({ format => filename })
     end
 


### PR DESCRIPTION
If you load Rails app, you can rely on autoloader to bring classes to you. This, for instance, lets you visualize state machine objects in lib folder